### PR TITLE
Add Presentation Mode for distraction-free screen sharing

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -35,6 +35,8 @@ export function AppShell() {
     openSettings,
     closeSettings,
     importModalOpen,
+    presentationMode,
+    togglePresentationMode,
   } = useUIStore();
 
   const isMobile = useIsMobile();
@@ -79,11 +81,15 @@ export function AppShell() {
           openSettings();
         }
       }
+      if (e.key === 'Escape' && presentationMode) {
+        e.preventDefault();
+        togglePresentationMode();
+      }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [quickSwitcherOpen, openQuickSwitcher, closeQuickSwitcher, graphViewOpen, openGraphView, closeGraphView, tasksViewOpen, openTasksView, closeTasksView, settingsOpen, openSettings, closeSettings]);
+  }, [quickSwitcherOpen, openQuickSwitcher, closeQuickSwitcher, graphViewOpen, openGraphView, closeGraphView, tasksViewOpen, openTasksView, closeTasksView, settingsOpen, openSettings, closeSettings, presentationMode, togglePresentationMode]);
 
   return (
     <div className="fixed inset-0 flex flex-col overflow-hidden">

--- a/src/components/layout/MainContent.tsx
+++ b/src/components/layout/MainContent.tsx
@@ -3,7 +3,7 @@ import { MilkdownEditor } from '../editor/MilkdownEditor';
 import { ShareModal } from '../share/ShareModal';
 import { useWorkspaceStore, useNoteStore, useUIStore } from '../../store';
 import { useIsMobile } from '../../hooks/useIsMobile';
-import { FileText, PanelLeft, PanelRight, Share2, Loader2, CheckSquare } from 'lucide-react';
+import { FileText, PanelLeft, PanelRight, Share2, Loader2, CheckSquare, X } from 'lucide-react';
 
 const GraphView = lazy(() =>
   import('../graph/GraphView').then(m => ({ default: m.GraphView }))
@@ -20,7 +20,7 @@ const TrashView = lazy(() =>
 export function MainContent() {
   const { tabs, activeTabId } = useWorkspaceStore();
   const { getNoteById, initialized } = useNoteStore();
-  const { sidebarVisible, rightPanelVisible, toggleSidebar, toggleRightPanel, graphViewOpen, closeGraphView, tasksViewOpen, openTasksView, closeTasksView, trashViewOpen, closeTrashView } = useUIStore();
+  const { sidebarVisible, rightPanelVisible, toggleSidebar, toggleRightPanel, graphViewOpen, closeGraphView, tasksViewOpen, openTasksView, closeTasksView, trashViewOpen, closeTrashView, presentationMode, togglePresentationMode } = useUIStore();
   const [showShareModal, setShowShareModal] = useState(false);
   const isMobile = useIsMobile();
 
@@ -84,7 +84,7 @@ export function MainContent() {
   return (
     <main className="flex flex-col flex-1 min-w-0 h-full bg-bg-primary">
       <div className="flex items-stretch h-[38px] bg-bg-secondary border-b border-border-primary">
-        {(!sidebarVisible || isMobile) && (
+        {!presentationMode && (!sidebarVisible || isMobile) && (
           <button
             onClick={toggleSidebar}
             className="self-center p-2.5 md:p-1.5 m-1 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors cursor-pointer"
@@ -101,14 +101,26 @@ export function MainContent() {
           <div className="flex-1" />
         )}
         <div className="flex items-center ml-auto self-center">
-          <button
-            onClick={tasksViewOpen ? closeTasksView : openTasksView}
-            className="p-2.5 md:p-1.5 m-1 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors cursor-pointer"
-            title="Tasks (Cmd+Shift+T)"
-          >
-            <CheckSquare size={16} />
-          </button>
-          {activeNote && (
+          {presentationMode && (
+            <button
+              onClick={togglePresentationMode}
+              className="flex items-center gap-1.5 px-2 py-1 m-1 rounded text-xs bg-accent/15 text-accent hover:bg-accent/25 transition-colors cursor-pointer"
+              title="Exit presentation mode (Escape)"
+            >
+              <X size={14} />
+              <span>Exit Presentation</span>
+            </button>
+          )}
+          {!presentationMode && (
+            <button
+              onClick={tasksViewOpen ? closeTasksView : openTasksView}
+              className="p-2.5 md:p-1.5 m-1 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors cursor-pointer"
+              title="Tasks (Cmd+Shift+T)"
+            >
+              <CheckSquare size={16} />
+            </button>
+          )}
+          {!presentationMode && activeNote && (
             <button
               onClick={() => setShowShareModal(true)}
               className="p-2.5 md:p-1.5 m-1 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors cursor-pointer"
@@ -117,7 +129,7 @@ export function MainContent() {
               <Share2 size={16} />
             </button>
           )}
-          {(!rightPanelVisible || isMobile) && (
+          {!presentationMode && (!rightPanelVisible || isMobile) && (
             <button
               onClick={toggleRightPanel}
               className="p-2.5 md:p-1.5 m-1 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors cursor-pointer"

--- a/src/components/layout/RightPanel.tsx
+++ b/src/components/layout/RightPanel.tsx
@@ -3,12 +3,12 @@ import { useUIStore } from '../../store';
 import { useIsMobile } from '../../hooks/useIsMobile';
 import { BacklinksPanel } from '../panels/BacklinksPanel';
 import { OutlinePanel } from '../panels/OutlinePanel';
-import { PanelRightClose, Link2, List } from 'lucide-react';
+import { PanelRightClose, Link2, List, Presentation } from 'lucide-react';
 
 type PanelTab = 'backlinks' | 'outline';
 
 export function RightPanel() {
-  const { rightPanelVisible, rightPanelWidth, toggleRightPanel } = useUIStore();
+  const { rightPanelVisible, rightPanelWidth, toggleRightPanel, togglePresentationMode } = useUIStore();
   const [activeTab, setActiveTab] = useState<PanelTab>('outline');
   const isMobile = useIsMobile();
 
@@ -52,13 +52,22 @@ export function RightPanel() {
             <span>Backlinks</span>
           </button>
         </div>
-        <button
-          onClick={toggleRightPanel}
-          className="p-2.5 md:p-1.5 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors cursor-pointer"
-          title="Close panel"
-        >
-          <PanelRightClose size={16} />
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={togglePresentationMode}
+            className="p-2.5 md:p-1.5 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors cursor-pointer"
+            title="Presentation mode"
+          >
+            <Presentation size={16} />
+          </button>
+          <button
+            onClick={toggleRightPanel}
+            className="p-2.5 md:p-1.5 rounded hover:bg-bg-hover text-text-muted hover:text-text-primary transition-colors cursor-pointer"
+            title="Close panel"
+          >
+            <PanelRightClose size={16} />
+          </button>
+        </div>
       </div>
       <div className="flex-1 overflow-y-auto scrollbar-thin">
         {activeTab === 'backlinks' ? (

--- a/src/components/workspace/TabBar.tsx
+++ b/src/components/workspace/TabBar.tsx
@@ -1,16 +1,19 @@
-import { useWorkspaceStore } from '../../store';
+import { useWorkspaceStore, useUIStore } from '../../store';
 import { X } from 'lucide-react';
 
 export function TabBar() {
   const { tabs, activeTabId, setActiveTab, closeTab } = useWorkspaceStore();
+  const { presentationMode } = useUIStore();
 
   if (tabs.length === 0) {
     return null;
   }
 
+  const visibleTabs = presentationMode ? tabs.filter(t => t.id === activeTabId) : tabs;
+
   return (
     <div className="flex items-center overflow-hidden" style={{ height: 'calc(100% + 1px)' }}>
-      {tabs.map(tab => (
+      {visibleTabs.map(tab => (
         <div
           key={tab.id}
           className={`

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -17,6 +17,8 @@ interface UIState {
   tasksViewOpen: boolean;
   trashViewOpen: boolean;
   importModalOpen: boolean;
+  presentationMode: boolean;
+  prePresentationState: { sidebarVisible: boolean; rightPanelVisible: boolean } | null;
 
   toggleSidebar: () => void;
   setSidebarWidth: (width: number) => void;
@@ -34,6 +36,7 @@ interface UIState {
   closeTrashView: () => void;
   openImportModal: () => void;
   closeImportModal: () => void;
+  togglePresentationMode: () => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -49,6 +52,8 @@ export const useUIStore = create<UIState>()(
       tasksViewOpen: false,
       trashViewOpen: false,
       importModalOpen: false,
+      presentationMode: false,
+      prePresentationState: null,
 
       toggleSidebar: () => set(state => ({ sidebarVisible: !state.sidebarVisible })),
       setSidebarWidth: (width: number) => set({ sidebarWidth: Math.max(200, Math.min(400, width)) }),
@@ -66,6 +71,29 @@ export const useUIStore = create<UIState>()(
       closeTrashView: () => set({ trashViewOpen: false }),
       openImportModal: () => set({ importModalOpen: true }),
       closeImportModal: () => set({ importModalOpen: false }),
+      togglePresentationMode: () => set(state => {
+        if (state.presentationMode) {
+          // Exiting: restore previous state
+          const prev = state.prePresentationState;
+          return {
+            presentationMode: false,
+            prePresentationState: null,
+            sidebarVisible: prev?.sidebarVisible ?? state.sidebarVisible,
+            rightPanelVisible: prev?.rightPanelVisible ?? state.rightPanelVisible,
+          };
+        } else {
+          // Entering: save state and hide panels
+          return {
+            presentationMode: true,
+            prePresentationState: {
+              sidebarVisible: state.sidebarVisible,
+              rightPanelVisible: state.rightPanelVisible,
+            },
+            sidebarVisible: false,
+            rightPanelVisible: false,
+          };
+        }
+      }),
     }),
     {
       name: 'noted-ui',


### PR DESCRIPTION
## Summary
- Adds a Presentation Mode toggle button in the right sidebar header for distraction-free screen sharing
- When enabled: hides both sidebars and shows only the active tab in the tab bar
- When disabled: restores all UI elements to their previous state
- Saves/restores sidebar visibility state so user preferences are preserved

## Changes
- `uiStore.ts` — Added `presentationMode` state with `togglePresentationMode()` that saves and restores sidebar/panel visibility
- `RightPanel.tsx` — Added Presentation toggle button in the header
- `MainContent.tsx` — Hides sidebars when presentation mode is active
- `TabBar.tsx` — Hides inactive tabs in presentation mode
- `AppShell.tsx` — Keyboard shortcut support

Closes #1

## Test plan
- [ ] Toggle presentation mode on — verify both sidebars hide and only the active tab is shown
- [ ] Toggle presentation mode off — verify sidebars restore to their previous state
- [ ] Open presentation mode with left sidebar hidden — verify it stays hidden when exiting
- [ ] Test during screen sharing over Zoom to confirm clean view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added presentation mode for a focused, distraction-free viewing experience
* Presentation mode hides the sidebar, right panel, and non-active tabs
* Toggle presentation mode from the right panel or exit using the Escape key
* Panel visibility is automatically restored when exiting presentation mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->