### PR TITLE
Add Bear App as an import source

### DIFF
--- a/src/services/import/bearImport.ts
+++ b/src/services/import/bearImport.ts
@@ -1,0 +1,135 @@
+import type { ImportResult } from './obsidianImport';
+import type { NoteFrontmatter } from '../../types';
+import { parseFrontmatter } from '../parser/markdownParser';
+
+/** Extract Bear-style inline tags (#tag, #tag/subtag) from markdown content. */
+function extractBearTags(content: string): string[] {
+  const tags = new Set<string>();
+  // Match #tag or #tag/subtag, but not inside code blocks or headings
+  // Bear tags: start with # followed by word chars, optionally /word chars
+  const lines = content.split('\n');
+  let inCodeBlock = false;
+
+  for (const line of lines) {
+    if (line.trimStart().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) continue;
+
+    // Skip headings (# Title, ## Title, etc.)
+    if (/^#{1,6}\s/.test(line.trimStart())) continue;
+
+    // Match Bear-style tags: #word or #word/word (not preceded by &)
+    const tagRegex = /(?:^|(?<=\s))#([\w][\w-]*(?:\/[\w][\w-]*)*)(?=\s|$|[.,;:!?)}\]])/g;
+    let match;
+    while ((match = tagRegex.exec(line)) !== null) {
+      tags.add(match[1]);
+    }
+  }
+
+  return Array.from(tags);
+}
+
+/** Convert Bear-specific syntax to standard markdown. */
+function convertBearSyntax(content: string): string {
+  let result = content;
+
+  // Convert ::highlighted text:: to **highlighted text**
+  result = result.replace(/::(.*?)::/g, '**$1**');
+
+  // Convert -- (bare horizontal rule) to ---
+  // Only match lines that are exactly -- (with optional whitespace)
+  result = result.replace(/^--\s*$/gm, '---');
+
+  return result;
+}
+
+/** Build folder entries from Bear tags. */
+function buildFoldersFromTags(
+  tags: string[],
+  folders: Map<string, { name: string; path: string; parentPath: string | null }>
+) {
+  for (const tag of tags) {
+    const parts = tag.split('/');
+    for (let i = 0; i < parts.length; i++) {
+      const folderPath = '/' + parts.slice(0, i + 1).join('/');
+      if (!folders.has(folderPath)) {
+        const parentPath = i === 0 ? null : '/' + parts.slice(0, i).join('/');
+        folders.set(folderPath, {
+          name: parts[i],
+          path: folderPath,
+          parentPath,
+        });
+      }
+    }
+  }
+}
+
+export async function parseBearExport(files: FileList): Promise<ImportResult> {
+  const folders = new Map<string, { name: string; path: string; parentPath: string | null }>();
+  const notes: ImportResult['notes'] = [];
+  const skipped: ImportResult['skipped'] = [];
+
+  for (const file of Array.from(files)) {
+    const relativePath = file.webkitRelativePath;
+    // Strip the root folder name (first segment)
+    const parts = relativePath.split('/');
+    const pathWithinExport = parts.slice(1).join('/');
+
+    if (!pathWithinExport) continue;
+
+    // Skip hidden files
+    if (pathWithinExport.startsWith('.') || pathWithinExport.includes('/.')) {
+      skipped.push({ path: pathWithinExport, reason: 'Hidden file' });
+      continue;
+    }
+
+    // Only process .md files
+    if (!file.name.endsWith('.md')) {
+      skipped.push({ path: pathWithinExport, reason: 'Not a markdown file (attachment)' });
+      continue;
+    }
+
+    const content = await file.text();
+    const convertedContent = convertBearSyntax(content);
+
+    // Extract title from first heading or filename
+    const headingMatch = convertedContent.match(/^#\s+(.+)$/m);
+    const title = headingMatch ? headingMatch[1].trim() : file.name.replace(/\.md$/, '');
+
+    // Extract Bear tags and build folder structure from them
+    const tags = extractBearTags(content);
+    buildFoldersFromTags(tags, folders);
+
+    // Determine which folder this note belongs to based on its first tag
+    const primaryTag = tags[0] ?? null;
+    const folderPath = primaryTag ? '/' + primaryTag : null;
+
+    // Build frontmatter - include Bear tags
+    const existingFrontmatter = parseFrontmatter(convertedContent) as NoteFrontmatter;
+    const frontmatter: NoteFrontmatter = {
+      ...existingFrontmatter,
+      ...(tags.length > 0 ? { tags } : {}),
+    };
+
+    const notePath = folderPath
+      ? folderPath + '/' + file.name.replace(/\.md$/, '')
+      : '/' + file.name.replace(/\.md$/, '');
+
+    notes.push({
+      title,
+      path: notePath,
+      folderPath,
+      content: convertedContent,
+      frontmatter,
+    });
+  }
+
+  // Sort folders by depth so parents come first
+  const sortedFolders = Array.from(folders.values()).sort(
+    (a, b) => a.path.split('/').length - b.path.split('/').length
+  );
+
+  return { folders: sortedFolders, notes, skipped };
+}

--- a/src/services/import/index.ts
+++ b/src/services/import/index.ts
@@ -1,4 +1,5 @@
 export { parseObsidianVault } from './obsidianImport';
 export type { ImportResult } from './obsidianImport';
+export { parseBearExport } from './bearImport';
 export { importNotes } from './importNotes';
 export type { ImportProgress } from './importNotes';


### PR DESCRIPTION
## Summary
- Adds Bear as an import source alongside the existing Obsidian import
- Parses Bear-exported markdown files, converting Bear-specific syntax and extracting tags into folder hierarchy
- Supports Bear's `#tag/subtag` notation, `::highlights::`, and other Bear-specific markdown

## Changes
- `bearImport.ts` — New parser for Bear export format: extracts `#tags` into folder hierarchy, converts `::highlights::` to bold, handles Bear-specific markdown
- `ImportModal.tsx` — Added Bear as a source option in the import source selection step
- `index.ts` — Re-exports the new Bear import module

Closes #4

## Test plan
- [ ] Export notes from Bear as markdown and import them
- [ ] Verify Bear tags (`#work/project`) create proper folder hierarchy
- [ ] Verify `::highlighted text::` is converted appropriately
- [ ] Verify standard markdown content imports correctly
- [ ] Verify non-markdown files are listed in skipped files
- [ ] Verify Obsidian import still works as before