### PR TITLE
Add JIRA integration for sprint status reports

### DIFF
--- a/src/utils/generateSprintStatus.ts
+++ b/src/utils/generateSprintStatus.ts
@@ -1,0 +1,59 @@
+import type { JiraIssue, JiraSprint } from './jiraApi';
+
+function formatTimeInStatus(statuscategorychangedate: string | undefined): string {
+  if (!statuscategorychangedate) return '-';
+
+  const changed = new Date(statuscategorychangedate);
+  const now = new Date();
+  const diffMs = now.getTime() - changed.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return 'today';
+  if (diffDays === 1) return '1 day';
+  return `${diffDays} days`;
+}
+
+export function generateSprintStatus(sprint: JiraSprint, issues: JiraIssue[]): string {
+  const date = new Date().toISOString().split('T')[0];
+  const lines: string[] = [];
+
+  lines.push(`# Sprint Status ${date}`);
+  lines.push('');
+  if (sprint.name) {
+    lines.push(`**Sprint:** ${sprint.name}`);
+    lines.push('');
+  }
+
+  // Group by assignee
+  const byAssignee = new Map<string, JiraIssue[]>();
+  for (const issue of issues) {
+    const name = issue.fields.assignee?.displayName ?? 'Unassigned';
+    const list = byAssignee.get(name) ?? [];
+    list.push(issue);
+    byAssignee.set(name, list);
+  }
+
+  // Sort assignees alphabetically, but put Unassigned last
+  const sortedNames = [...byAssignee.keys()].sort((a, b) => {
+    if (a === 'Unassigned') return 1;
+    if (b === 'Unassigned') return -1;
+    return a.localeCompare(b);
+  });
+
+  for (const name of sortedNames) {
+    const assigneeIssues = byAssignee.get(name)!;
+    lines.push(`## ${name}`);
+    lines.push('');
+    lines.push('| Ticket | Status | Time in Status |');
+    lines.push('|--------|--------|----------------|');
+
+    for (const issue of assigneeIssues) {
+      const timeInStatus = formatTimeInStatus(issue.fields.statuscategorychangedate);
+      lines.push(`| ${issue.key} | ${issue.fields.status.name} | ${timeInStatus} |`);
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/src/utils/jiraApi.ts
+++ b/src/utils/jiraApi.ts
@@ -1,0 +1,84 @@
+// JIRA REST API client
+// Note: JIRA API calls from the browser will hit CORS restrictions.
+// Users must configure their JIRA instance to allow CORS from the app origin,
+// or use a CORS proxy.
+
+export interface JiraConfig {
+  instanceUrl: string;
+  email: string;
+  apiToken: string;
+}
+
+export interface JiraBoard {
+  id: number;
+  name: string;
+  type: string;
+}
+
+export interface JiraSprint {
+  id: number;
+  name: string;
+  state: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface JiraIssue {
+  key: string;
+  fields: {
+    summary: string;
+    status: { name: string };
+    assignee: { displayName: string } | null;
+    statuscategorychangedate?: string;
+  };
+}
+
+function authHeader(config: JiraConfig): string {
+  return 'Basic ' + btoa(config.email + ':' + config.apiToken);
+}
+
+async function jiraFetch<T>(config: JiraConfig, path: string): Promise<T> {
+  const url = `${config.instanceUrl.replace(/\/+$/, '')}${path}`;
+  const response = await fetch(url, {
+    headers: {
+      'Authorization': authHeader(config),
+      'Accept': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`JIRA API error ${response.status}: ${text || response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export async function getBoards(config: JiraConfig): Promise<JiraBoard[]> {
+  const data = await jiraFetch<{ values: JiraBoard[] }>(
+    config,
+    '/rest/agile/1.0/board'
+  );
+  return data.values;
+}
+
+export async function getActiveSprint(config: JiraConfig, boardId: string): Promise<JiraSprint | null> {
+  const data = await jiraFetch<{ values: JiraSprint[] }>(
+    config,
+    `/rest/agile/1.0/board/${boardId}/sprint?state=active`
+  );
+  return data.values[0] ?? null;
+}
+
+export async function getSprintIssues(config: JiraConfig, sprintId: number): Promise<JiraIssue[]> {
+  const data = await jiraFetch<{ issues: JiraIssue[] }>(
+    config,
+    `/rest/agile/1.0/sprint/${sprintId}/issue?maxResults=200`
+  );
+  return data.issues;
+}
+
+export async function testConnection(config: JiraConfig): Promise<boolean> {
+  await jiraFetch<unknown>(config, '/rest/api/3/myself');
+  return true;
+}


### PR DESCRIPTION
## Summary
- Adds JIRA integration with PAT authentication for generating sprint status reports
- Configurable in Settings with instance URL, email, API token, board ID, and target folder
- "Generate Sprint Status" button appears in the sidebar when JIRA is configured
- Generates markdown reports grouped by team member with ticket status tables

## Changes
- `jiraApi.ts` — New JIRA REST API client (boards, active sprint, sprint issues) with Basic auth
- `generateSprintStatus.ts` — Generates markdown report grouped by assignee with status and time-in-status tables
- `settingsStore.ts` — Added JIRA configuration settings (instance URL, email, API token, board ID, folder)
- `SettingsModal.tsx` — Added JIRA Integration configuration section with test connection button
- `Sidebar.tsx` — Added "Generate Sprint Status" button, visible when JIRA is configured

Closes #5

## Test plan
- [ ] Configure JIRA credentials in Settings and test connection
- [ ] Verify "Generate Sprint Status" button appears in sidebar after configuration
- [ ] Click the button — verify it fetches sprint data and creates a new note
- [ ] Verify the generated note is named "Sprint Status YYYY-MM-DD" and saved to the configured folder
- [ ] Verify the report format matches the spec (grouped by assignee, table with ticket/status/time)
- [ ] Verify button is hidden when JIRA is not configured